### PR TITLE
Accept　OP_RETURN transaction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -561,7 +561,7 @@ bool CTransaction::CheckTransaction() const
             return DoS(100, error("CTransaction::CheckTransaction() : txout empty for user transaction"));
 
         // ppcoin: enforce minimum output amount
-        if ((!txout.IsEmpty()) && txout.nValue < MIN_TXOUT_AMOUNT)
+        if ((!txout.IsEmpty()) && txout.nValue < MIN_TXOUT_AMOUNT && txout.scriptPubKey[0] != OP_RETURN )
             return DoS(100, error("CTransaction::CheckTransaction() : txout.nValue below minimum"));
 
         if (txout.nValue > MAX_MONEY)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,9 +368,9 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
             reason = "scriptpubkey";
             return false;
         }
-        if (whichType == TX_NULL_DATA)
-            nDataOut++;
-        if (txout.nValue == 0) {
+		if (whichType == TX_NULL_DATA) {
+			nDataOut++;
+		}else if (txout.nValue == 0) {
             reason = "dust";
             return false;
         }
@@ -652,7 +652,7 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
     // Rather not work on nonstandard transactions (unless -testnet)
     string reason;
     if (!fTestNet && !IsStandardTx(tx, reason))
-	return error("CTxMemPool::accept() : nonstandard transaction type");
+	return error( ("CTxMemPool::accept() : nonstandard transaction type:"+ reason).c_str() );
 
     // Do we already have it?
     uint256 hash = tx.GetHash();


### PR DESCRIPTION
OP_RETURNをCoindのMempoolが受け入れるようにコードを書き換えました。
不味いところが無いか確認してください。
accept.mempool関数にも手を加える必要が出てきてしまった為、採掘者のCoindを新規にしなければブロックがフォークすることになります。